### PR TITLE
fix(Rashifal): bind scrape to rashifal

### DIFF
--- a/src/commands/General/utils/Rashifal.ts
+++ b/src/commands/General/utils/Rashifal.ts
@@ -21,7 +21,7 @@ class Rashifal {
     public TIMEOUT = 3600 * 3;
     constructor(@inject(kRedis) public readonly redis: Redis) {
         this.scrape();
-        setInterval(this.scrape, this.TIMEOUT * 1000).unref();
+        setInterval(this.scrape.bind(this), this.TIMEOUT * 1000).unref();
     }
 
     public async get(rashi: string) {


### PR DESCRIPTION
This fixes problems while using the scrape method with `setInterval` inside constructor. `this` won't be available to `scrape` when we use it like this:

```ts
setInterval(this.scrape, 1e4);
```

but binding `scrape` to the current instance fixes the issue.