### PR TITLE
chore(.env.example): add twitter api key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ REDIS_HOST=localhost:6379
 # Redis password (optional)
 # REDIS_PASSWORD=123456789
 
+#Twitter Bearer Token 
+TWITTER_API_KEY=xxxxxx
+
 # PostgreSQL
 DATABASE_URL="postgresql://JohnDoe:1234567890@localhost:5432/mydb?schema=public"


### PR DESCRIPTION
twitter env key was missing. 