### PR TITLE
refactor(BotinfoCommand): add last 3 commits

### DIFF
--- a/src/commands/General/BotinfoCommand.ts
+++ b/src/commands/General/BotinfoCommand.ts
@@ -67,21 +67,21 @@ export default class extends BaseCommand {
         const embed = new MessageEmbed()
             .setThumbnail(this.client.user.displayAvatarURL())
             .setAuthor(`Information about ${this.client.user.username} Bot`, this.client.user.displayAvatarURL())
-            .setDescription(`Last updates:\n${commits || "N/A"}`)
+            .setDescription(`**__Last updates:__**\n${commits || "N/A"}`)
             .addFields(
                 {
-                    name: "ID",
-                    value: this.client.user.id,
+                    name: "Basic Information",
+                    value: `${this.client.user.tag} (\`${this.client.user.id}\`)`,
                     inline: false
                 },
                 {
-                    name: "Created at",
+                    name: "Created",
                     value: `<t:${Math.floor(this.client.user.createdTimestamp / 1000)}:F> • <t:${Math.floor(this.client.user.createdTimestamp / 1000)}:R>`,
                     inline: false
                 },
                 {
                     name: "Uptime",
-                    value: formatMs(ms(this.client.uptime), ["months", "weeks", "days", "hours", "minutes", "seconds"]) || "N/A",
+                    value: formatMs(ms(this.client.uptime), ["months", "weeks", "days", "hours", "minutes", "seconds"]) || "1 second",
                     inline: false
                 },
                 {
@@ -119,23 +119,11 @@ export default class extends BaseCommand {
                     inline: true
                 },
                 {
-                    name: "Bot Tag",
-                    value: this.client.user.tag,
-                    inline: true
-                },
-                {
-                    name: "Server Count",
-                    value: this.client.guilds.cache.size.toString(),
-                    inline: true
-                },
-                {
-                    name: "Users",
-                    value: this.client.users.cache.size.toString(),
-                    inline: true
-                },
-                {
-                    name: "Channels",
-                    value: this.client.channels.cache.size.toString(),
+                    name: "Statistics",
+                    value: stripIndents`${Emojis.REPLY_BRANCH} Servers: ${this.client.guilds.cache.size.toLocaleString()}
+                    ${Emojis.REPLY_BRANCH} Users: ${this.client.users.cache.size.toLocaleString()}
+                    ${Emojis.REPLY_BRANCH} Channels: ${this.client.channels.cache.size.toLocaleString()}
+                    ${Emojis.REPLY} Shards: ${typeof this.client.shard?.count !== "number" ? 1 : this.client.shard?.count}`,
                     inline: true
                 }
             )

--- a/src/commands/General/BotinfoCommand.ts
+++ b/src/commands/General/BotinfoCommand.ts
@@ -27,20 +27,28 @@ export default class extends BaseCommand {
             const cached = await this.redis.get("moomin_bot::commits");
             if (cached) return resolve(cached.trim());
 
-            cpExec("git log --oneline -3", {
-                timeout: 30_000,
-                windowsHide: true
-            }, async (err, stdout) => {
-                if (err || !stdout) return resolve("N/A");
-                const res = stdout.split("\n").map((s) => {
-                    const [commit, ...msgs] = s.split(" ");
-                    return !commit ? "" : `[\`${commit}\`](https://github.com/MoominBot/MoominBot/commit/${commit}) ${msgs.join(" ")}`;
-                }).join("\n").trim();
+            cpExec(
+                "git log --oneline -3",
+                {
+                    timeout: 30_000,
+                    windowsHide: true
+                },
+                async (err, stdout) => {
+                    if (err || !stdout) return resolve("N/A");
+                    const res = stdout
+                        .split("\n")
+                        .map((s) => {
+                            const [commit, ...msgs] = s.split(" ");
+                            return !commit ? "" : `[\`${commit}\`](https://github.com/MoominBot/MoominBot/commit/${commit}) ${msgs.join(" ")}`;
+                        })
+                        .join("\n")
+                        .trim();
 
-                await this.redis.setex("moomin_bot::commits", 300, res);
+                    await this.redis.setex("moomin_bot::commits", 300, res);
 
-                resolve(res);
-            });
+                    resolve(res);
+                }
+            );
         });
     }
 
@@ -53,12 +61,7 @@ export default class extends BaseCommand {
         const actionRow = new MessageActionRow().addComponents(
             [new MessageButton().setLabel("Learn more").setURL("https://discord.gg/KryMr3Jy68").setStyle("LINK")],
             [new MessageButton().setLabel("Source code").setURL("https://github.com/MoominBot/MoominBot").setStyle("LINK")],
-            [
-                new MessageButton()
-                    .setLabel("Invite bot")
-                    .setURL(botInviteURL)
-                    .setStyle("LINK")
-            ]
+            [new MessageButton().setLabel("Invite bot").setURL(botInviteURL).setStyle("LINK")]
         );
 
         const embed = new MessageEmbed()
@@ -78,11 +81,7 @@ export default class extends BaseCommand {
                 },
                 {
                     name: "Uptime",
-                    value: formatMs(ms(this.client.uptime), [
-                        "months", "weeks",
-                        "days", "hours",
-                        "minutes", "seconds"
-                    ]) || "N/A",
+                    value: formatMs(ms(this.client.uptime), ["months", "weeks", "days", "hours", "minutes", "seconds"]) || "N/A",
                     inline: false
                 },
                 {

--- a/src/commands/General/BotinfoCommand.ts
+++ b/src/commands/General/BotinfoCommand.ts
@@ -2,35 +2,69 @@ import { Client, CommandInteraction, MessageEmbed, version, MessageActionRow, Me
 import { inject, injectable } from "tsyringe";
 
 import BaseCommand from "#base/BaseCommand";
-import { kClient } from "#utils/tokens";
+import { kClient, kRedis } from "#utils/tokens";
 
+import { Redis } from "ioredis";
 import os from "node:os";
 import { Emojis } from "#utils/constants";
 
+import { exec as cpExec } from "node:child_process";
+import ms, { format as formatMs } from "#utils/parse_ms";
+import { stripIndents } from "common-tags";
+
 @injectable()
 export default class extends BaseCommand {
-    constructor(@inject(kClient) public readonly client: Client<true>) {
+    constructor(@inject(kClient) public readonly client: Client<true>, @inject(kRedis) public redis: Redis) {
         super({
             name: "info",
             category: "General"
         });
     }
 
+    getCommits() {
+        // eslint-disable-next-line no-async-promise-executor
+        return new Promise<string>(async (resolve) => {
+            const cached = await this.redis.get("moomin_bot::commits");
+            if (cached) return resolve(cached.trim());
+
+            cpExec("git log --oneline -3", {
+                timeout: 30_000,
+                windowsHide: true
+            }, async (err, stdout) => {
+                if (err || !stdout) return resolve("N/A");
+                const res = stdout.split("\n").map((s) => {
+                    const [commit, ...msgs] = s.split(" ");
+                    return !commit ? "" : `[\`${commit}\`](https://github.com/MoominBot/MoominBot/commit/${commit}) ${msgs.join(" ")}`;
+                }).join("\n").trim();
+
+                await this.redis.setex("moomin_bot::commits", 300, res);
+
+                resolve(res);
+            });
+        });
+    }
+
     async execute(interaction: CommandInteraction) {
+        const commits = await this.getCommits();
+        const botInviteURL = this.client.generateInvite({
+            scopes: ["applications.commands", "bot"],
+            permissions: ["ADMINISTRATOR"]
+        });
         const actionRow = new MessageActionRow().addComponents(
-            [new MessageButton().setLabel("Learn More!").setURL("https://discord.gg/KryMr3Jy68").setStyle("LINK")],
-            [new MessageButton().setLabel("Source").setURL("https://github.com/MoominBot/MoominBot").setStyle("LINK")],
+            [new MessageButton().setLabel("Learn more").setURL("https://discord.gg/KryMr3Jy68").setStyle("LINK")],
+            [new MessageButton().setLabel("Source code").setURL("https://github.com/MoominBot/MoominBot").setStyle("LINK")],
             [
                 new MessageButton()
-                    .setLabel("Invite")
-                    .setURL("https://discord.com/oauth2/authorize?client_id=914812146716651541&permissions=-1&scope=bot%20applications.commands")
+                    .setLabel("Invite bot")
+                    .setURL(botInviteURL)
                     .setStyle("LINK")
             ]
         );
-        const uptime = Math.floor((Date.now() - this.client.uptime) / 1000);
+
         const embed = new MessageEmbed()
             .setThumbnail(this.client.user.displayAvatarURL())
             .setAuthor(`Information about ${this.client.user.username} Bot`, this.client.user.displayAvatarURL())
+            .setDescription(`Last updates:\n${commits || "N/A"}`)
             .addFields(
                 {
                     name: "ID",
@@ -43,8 +77,12 @@ export default class extends BaseCommand {
                     inline: false
                 },
                 {
-                    name: "Online Since",
-                    value: `<t:${uptime}:F> • <t:${uptime}:R> `,
+                    name: "Uptime",
+                    value: formatMs(ms(this.client.uptime), [
+                        "months", "weeks",
+                        "days", "hours",
+                        "minutes", "seconds"
+                    ]) || "N/A",
                     inline: false
                 },
                 {
@@ -68,8 +106,16 @@ export default class extends BaseCommand {
                     inline: true
                 },
                 {
-                    name: "Version",
-                    value: `${Emojis.REPLY_BRANCH} Bot Version: 0.1.0a\n${Emojis.REPLY} Node Version: ${process.version}`,
+                    name: "Versions",
+                    value: stripIndents`${Emojis.REPLY_BRANCH} Bot Version: 0.1.0a
+                    ${Emojis.REPLY_BRANCH} Node Version: ${process.version}
+                    ${Emojis.REPLY_BRANCH} V8: ${process.versions.v8}
+                    ${Emojis.REPLY} libuv: ${process.versions.uv}`,
+                    inline: true
+                },
+                {
+                    name: "\u200b",
+                    value: "\u200b",
                     inline: true
                 },
                 {

--- a/src/commands/General/BotinfoCommand.ts
+++ b/src/commands/General/BotinfoCommand.ts
@@ -95,13 +95,13 @@ export default class extends BaseCommand {
                     value: `${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB / ${Math.round(os.totalmem() / 1024 / 1024 / 1024)} GB`
                 },
                 {
-                    name: "Language",
-                    value: "TypeScript",
+                    name: "\u200b",
+                    value: "\u200b",
                     inline: true
                 },
                 {
-                    name: "Library",
-                    value: `Discord.js v${version}`,
+                    name: "Language",
+                    value: "TypeScript",
                     inline: true
                 },
                 {
@@ -109,6 +109,7 @@ export default class extends BaseCommand {
                     value: stripIndents`${Emojis.REPLY_BRANCH} Bot Version: 0.1.0a
                     ${Emojis.REPLY_BRANCH} Node Version: ${process.version}
                     ${Emojis.REPLY_BRANCH} V8: ${process.versions.v8}
+                    ${Emojis.REPLY_BRANCH} Discord.js: ${version}
                     ${Emojis.REPLY} libuv: ${process.versions.uv}`,
                     inline: true
                 },

--- a/src/utils/parse_ms.ts
+++ b/src/utils/parse_ms.ts
@@ -4,8 +4,8 @@ export default function ms(milliseconds: number): msPayload {
     if (typeof milliseconds !== "number") throw new TypeError("Invalid ms");
 
     return {
-        months: Math.trunc(milliseconds / 2.628e+9),
-        weeks: Math.trunc(milliseconds / 6.048e+8),
+        months: Math.trunc(milliseconds / 2.628e9),
+        weeks: Math.trunc(milliseconds / 6.048e8),
         days: Math.trunc(milliseconds / 86400000),
         hours: Math.trunc(milliseconds / 3600000) % 24,
         minutes: Math.trunc(milliseconds / 60000) % 60,
@@ -17,10 +17,14 @@ export default function ms(milliseconds: number): msPayload {
 }
 
 export function format(data: msPayload, fields: Array<keyof msPayload> = []) {
-    return Object.entries(data).filter((p) => fields.includes(p[0] as keyof msPayload)).map(([K, V]) => {
-        if (V < 1) return "";
-        return `${V} ${K}`;
-    }).filter(x => x.length > 0).join(", ");
+    return Object.entries(data)
+        .filter((p) => fields.includes(p[0] as keyof msPayload))
+        .map(([K, V]) => {
+            if (V < 1) return "";
+            return `${V} ${K}`;
+        })
+        .filter((x) => x.length > 0)
+        .join(", ");
 }
 
 export interface msPayload {

--- a/src/utils/parse_ms.ts
+++ b/src/utils/parse_ms.ts
@@ -1,0 +1,36 @@
+// https://github.com/sindresorhus/parse-ms/blob/bb173b5bba0bbb3b059732f9fdd7ab692a4ebaf7/index.js
+
+export default function ms(milliseconds: number): msPayload {
+    if (typeof milliseconds !== "number") throw new TypeError("Invalid ms");
+
+    return {
+        months: Math.trunc(milliseconds / 2.628e+9),
+        weeks: Math.trunc(milliseconds / 6.048e+8),
+        days: Math.trunc(milliseconds / 86400000),
+        hours: Math.trunc(milliseconds / 3600000) % 24,
+        minutes: Math.trunc(milliseconds / 60000) % 60,
+        seconds: Math.trunc(milliseconds / 1000) % 60,
+        milliseconds: Math.trunc(milliseconds) % 1000,
+        microseconds: Math.trunc(milliseconds * 1000) % 1000,
+        nanoseconds: Math.trunc(milliseconds * 1e6) % 1000
+    };
+}
+
+export function format(data: msPayload, fields: Array<keyof msPayload> = []) {
+    return Object.entries(data).filter((p) => fields.includes(p[0] as keyof msPayload)).map(([K, V]) => {
+        if (V < 1) return "";
+        return `${V} ${K}`;
+    }).filter(x => x.length > 0).join(", ");
+}
+
+export interface msPayload {
+    months: number;
+    weeks: number;
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+    microseconds: number;
+    nanoseconds: number;
+}


### PR DESCRIPTION
This PR adds last 3 commits to bot info command:

![image](https://user-images.githubusercontent.com/46562212/145682514-00c0daf1-67cc-4f63-821e-fc1e4b632f7c.png)

The commit history is cached for 5 minutes.

Overall visualization:

![image](https://user-images.githubusercontent.com/46562212/145682529-ab7858c8-5234-4573-9e3a-7f39327b4bc5.png)
